### PR TITLE
Resolve config from file, if supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,16 @@ matrix:
   include:
   - node_js: stable
     env: PEER_GULP=true
-  - node_js: stable
-    env: PEER_PRETTIER=true
 
 before_install:
 - yarn global add codecov
 
 before_script:
 - if [ "$PEER_GULP" = "true" ]; then node ./scripts/install-peer gulp; fi
-- if [ "$PEER_PRETTIER" = "true" ]; then node ./scripts/install-peer prettier; fi
 
 script:
 - yarn run lint
-- yarn run format-check || [ "$PEER_PRETTIER" = "true" ]
+- yarn run format-check
 - yarn run test -- --coverage --verbose
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ export interface PluginOptions {
    * omit formatted files
    */
   filter?: boolean;
+  /**
+   * default: true
+   * include rules from Prettier config files, e.g. .prettierrc
+   */
+  configFile?: boolean;
 }
 
 export const enum Reporter {

--- a/fixtures/with_config/.prettierrc
+++ b/fixtures/with_config/.prettierrc
@@ -1,0 +1,6 @@
+printWidth: 100
+useTabs: true
+semi: false
+singleQuote: true
+trailingComma: "all"
+bracketSpacing: false

--- a/fixtures/with_config/unformatted.js
+++ b/fixtures/with_config/unformatted.js
@@ -1,0 +1,5 @@
+export function some_function(a) {
+  return {
+    c: a+"b"
+  };
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "prepublish": "yarn run build",
     "lint": "tslint -p ./tsconfig.json --type-check",
-    "test": "jest --config ./jest.json",
+    "test": "jest -c ./jest.json",
     "prebuild": "rm -rf ./lib",
     "build": "tsc -p tsconfig.build.json",
     "format": "gulp format",

--- a/src/format.ts
+++ b/src/format.ts
@@ -26,6 +26,7 @@ export function format(
   { reporter = Reporter.Warning, filter = false }: PluginOptions = {},
 ) {
   return create_transform(async (text, filename) => {
+    // tslint:disable-next-line:strict-type-predicates
     const resolved_config = await (typeof prettier.resolveConfig === 'function'
       ? prettier.resolveConfig(filename)
       : Promise.resolve(null));

--- a/src/format.ts
+++ b/src/format.ts
@@ -19,17 +19,26 @@ export interface PluginOptions {
    * omit formatted files
    */
   filter?: boolean;
+  /**
+   * include rules from Prettier config files, e.g. .prettierrc
+   */
+  configFile?: boolean;
 }
 
 export function format(
   prettier_options: Options = {},
-  { reporter = Reporter.Warning, filter = false }: PluginOptions = {},
+  {
+    reporter = Reporter.Warning,
+    filter = false,
+    configFile: config_file = true,
+  }: PluginOptions = {},
 ) {
   return create_transform(async (text, filename) => {
     // tslint:disable-next-line:strict-type-predicates
-    const resolved_config = await (typeof prettier.resolveConfig === 'function'
-      ? prettier.resolveConfig(filename)
-      : Promise.resolve(null));
+    const resolved_config =
+      config_file && typeof prettier.resolveConfig === 'function'
+        ? await prettier.resolveConfig(filename)
+        : null;
 
     const formatted = prettier.format(text, {
       ...resolved_config,

--- a/src/format.ts
+++ b/src/format.ts
@@ -34,9 +34,8 @@ export function format(
   }: PluginOptions = {},
 ) {
   return create_transform(async (text, filename) => {
-    // tslint:disable-next-line:strict-type-predicates
     const resolved_config =
-      config_file && typeof prettier.resolveConfig === 'function'
+      config_file && typeof prettier.resolveConfig === 'function' // tslint:disable-line:strict-type-predicates
         ? await prettier.resolveConfig(filename)
         : null;
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -25,8 +25,13 @@ export function format(
   prettier_options: Options = {},
   { reporter = Reporter.Warning, filter = false }: PluginOptions = {},
 ) {
-  return create_transform((text, filename) => {
+  return create_transform(async (text, filename) => {
+    const resolved_config = await (typeof prettier.resolveConfig === 'function'
+      ? prettier.resolveConfig(filename)
+      : Promise.resolve(null));
+
     const formatted = prettier.format(text, {
+      ...resolved_config,
       ...prettier_options,
       filepath:
         prettier_options.filepath !== undefined

--- a/src/utils/create-transform.ts
+++ b/src/utils/create-transform.ts
@@ -7,7 +7,10 @@ import stream = require('stream');
 // tslint:disable-next-line:no-var-requires
 const package_name = require('../../package.json').name;
 
-export type Transformer = (text: string, filename: string) => TransformResult;
+export type Transformer = (
+  text: string,
+  filename: string,
+) => Promise<TransformResult>;
 export interface TransformResult {
   formatted: string | null;
   different: boolean;
@@ -31,13 +34,19 @@ export function create_transform(transformer: Transformer) {
       const output_file: gulp_util.File = input_file.clone();
       try {
         const text = input_file.contents.toString('utf8');
-        const { formatted, different } = transformer(text, input_file.path);
-        if (formatted === null) {
-          output_file.contents = null;
-        } else if (different) {
-          output_file.contents = new Buffer(formatted);
-        }
-        callback(null, output_file);
+        transformer(text, input_file.path)
+          .then(({ formatted, different }) => {
+            if (formatted === null) {
+              output_file.contents = null;
+            } else if (different) {
+              output_file.contents = new Buffer(formatted);
+            }
+            callback(null, output_file);
+          })
+          .catch(e => {
+            const error = e as Error;
+            callback(new gulp_util.PluginError(package_name, error.message));
+          });
       } catch (e) {
         const error = e as Error;
         callback(new gulp_util.PluginError(package_name, error.message));

--- a/src/utils/create-transform.ts
+++ b/src/utils/create-transform.ts
@@ -32,25 +32,20 @@ export function create_transform(transformer: Transformer) {
         return;
       }
       const output_file: gulp_util.File = input_file.clone();
-      try {
-        const text = input_file.contents.toString('utf8');
-        transformer(text, input_file.path)
-          .then(({ formatted, different }) => {
-            if (formatted === null) {
-              output_file.contents = null;
-            } else if (different) {
-              output_file.contents = new Buffer(formatted);
-            }
-            callback(null, output_file);
-          })
-          .catch(e => {
-            const error = e as Error;
-            callback(new gulp_util.PluginError(package_name, error.message));
-          });
-      } catch (e) {
-        const error = e as Error;
-        callback(new gulp_util.PluginError(package_name, error.message));
-      }
+      const text = input_file.contents.toString('utf8');
+      transformer(text, input_file.path)
+        .then(({ formatted, different }) => {
+          if (formatted === null) {
+            output_file.contents = null;
+          } else if (different) {
+            output_file.contents = new Buffer(formatted);
+          }
+          callback(null, output_file);
+        })
+        .catch(e => {
+          const error = e as Error;
+          callback(new gulp_util.PluginError(package_name, error.message));
+        });
     },
   );
 }

--- a/tests/__snapshots__/index.ts.snap
+++ b/tests/__snapshots__/index.ts.snap
@@ -11,6 +11,15 @@ exports[`unformatted.css + default 1`] = `
 "
 `;
 
+exports[`unformatted.js + configFile(false) 1`] = `
+"export function some_function(a) {
+  return {
+    c: a + \\"b\\"
+  };
+}
+"
+`;
+
 exports[`unformatted.js + default 1`] = `
 "export function some_function(a) {
 	return {
@@ -24,6 +33,15 @@ exports[`unformatted.js + old prettier 1`] = `
 "export function some_function(a) {
   return {
     c: a + \\"b\\"
+  };
+}
+"
+`;
+
+exports[`unformatted.js + trailingComma(all) + configFile(false) 1`] = `
+"export function some_function(a) {
+  return {
+    c: a + \\"b\\",
   };
 }
 "

--- a/tests/__snapshots__/index.ts.snap
+++ b/tests/__snapshots__/index.ts.snap
@@ -11,6 +11,24 @@ exports[`unformatted.css + default 1`] = `
 "
 `;
 
+exports[`unformatted.js + default 1`] = `
+"export function some_function(a) {
+	return {
+		c: a + 'b',
+	}
+}
+"
+`;
+
+exports[`unformatted.js + trailingComma(none) 1`] = `
+"export function some_function(a) {
+	return {
+		c: a + 'b'
+	}
+}
+"
+`;
+
 exports[`unformatted.ts + default 1`] = `
 "export function some_function(a) {
   return {

--- a/tests/__snapshots__/index.ts.snap
+++ b/tests/__snapshots__/index.ts.snap
@@ -20,6 +20,15 @@ exports[`unformatted.js + default 1`] = `
 "
 `;
 
+exports[`unformatted.js + old prettier 1`] = `
+"export function some_function(a) {
+  return {
+    c: a + \\"b\\"
+  };
+}
+"
+`;
+
 exports[`unformatted.js + trailingComma(none) 1`] = `
 "export function some_function(a) {
 	return {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -36,6 +36,28 @@ test('unformatted.js + trailingComma(none)', done => {
   });
 });
 
+test('unformatted.js + configFile(false)', done => {
+  const task = create_task('with_config/unformatted.js', undefined, {
+    configFile: false,
+  });
+  gulp.start(task.name, () => {
+    expect(task.result.formatted).toMatchSnapshot();
+    done();
+  });
+});
+
+test('unformatted.js + trailingComma(all) + configFile(false)', done => {
+  const task = create_task(
+    'with_config/unformatted.js',
+    { trailingComma: 'all' },
+    { configFile: false },
+  );
+  gulp.start(task.name, () => {
+    expect(task.result.formatted).toMatchSnapshot();
+    done();
+  });
+});
+
 test('unformatted.js + old prettier', done => {
   const resolve_config = require('prettier').resolveConfig;
   require('prettier').resolveConfig = undefined;

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -16,6 +16,26 @@ test('unformatted.ts + default', done => {
   });
 });
 
+test('unformatted.js + default', done => {
+  const task = create_task('with_config/unformatted.js', undefined, undefined);
+  gulp.start(task.name, () => {
+    expect(task.result.formatted).toMatchSnapshot();
+    done();
+  });
+});
+
+test('unformatted.js + trailingComma(none)', done => {
+  const task = create_task(
+    'with_config/unformatted.js',
+    { trailingComma: 'none' },
+    undefined,
+  );
+  gulp.start(task.name, () => {
+    expect(task.result.formatted).toMatchSnapshot();
+    done();
+  });
+});
+
 test('unformatted.css + default', done => {
   const task = create_task('unformatted.css', undefined, undefined);
   gulp.start(task.name, () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -36,6 +36,23 @@ test('unformatted.js + trailingComma(none)', done => {
   });
 });
 
+test('unformatted.js + old prettier', done => {
+  const resolve_config = require('prettier').resolveConfig;
+  require('prettier').resolveConfig = undefined;
+
+  const task = create_task(
+    'with_config/unformatted.js',
+    { trailingComma: 'none' },
+    undefined,
+  );
+  gulp.start(task.name, () => {
+    expect(task.result.formatted).toMatchSnapshot();
+    done();
+
+    require('prettier').resolveConfig = resolve_config;
+  });
+});
+
 test('unformatted.css + default', done => {
   const task = create_task('unformatted.css', undefined, undefined);
   gulp.start(task.name, () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -140,7 +140,7 @@ function create_task(
     return !catch_result
       ? stream
       : stream.pipe(
-          create_transform(text => {
+          create_transform(async text => {
             result.counter++;
             result.formatted = text;
             return { formatted: text, different: false };


### PR DESCRIPTION
Since the `peerDependency` for prettier is `^1.4.0`, `resolveConfig` may not be implemented yet, so I first check if it is defined (which causes an error with the TypeScript definition).

Let me know if there are any other changes you'd like to see.

Hope it helps!